### PR TITLE
fixed some error for this project can run.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -126,7 +126,7 @@ class TetrisEngine(object):
     def __init__(self, width, height):
         self.width = width
         self.height = height
-        self.board = np.zeros(shape=(width, height), dtype=np.bool)
+        self.board = np.zeros(shape=(width, height), dtype=bool)
 
         self.shapes = Shapes()
         self.actions = Actions()
@@ -207,7 +207,7 @@ class TetrisEngine(object):
         keep_lines, = np.where(~cleared)
         self.cleared_lines += num_cleared
         self.board = np.concatenate([
-            np.zeros(shape=(self.width, num_cleared), dtype=np.bool),
+            np.zeros(shape=(self.width, num_cleared), dtype=bool),
             self.board[:, keep_lines],
         ], axis=1)
         self._update_score(cleared_lines=num_cleared)

--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,11 @@ class Getch(object):
             self.impl = self.init_unix()
 
     def __call__(self):
-        return self.impl()
+        target = self.impl()
+        if isinstance(target, str):
+            return target
+        else:
+            return target.decode()
 
     def init_windows(self):
         import msvcrt


### PR DESCRIPTION
# 1

edit np.bool to bool, module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

# 2

Getch.__call__ returns type is "bytes", edit to "str".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace deprecated `np.bool` with `bool` in `engine.py` and make `Getch.__call__` return `str` by decoding bytes.
> 
> - **Engine (`engine.py`)**:
>   - Replace deprecated `np.bool` with built-in `bool` for board initialization and line-clearing buffers.
> - **Utils (`utils.py`)**:
>   - Ensure `Getch.__call__` returns `str` consistently by decoding byte results from platform-specific implementations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89fb15730ce3250829a150d79321f23f53064408. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->